### PR TITLE
Action's meta information saving support

### DIFF
--- a/actions-beans/pom.xml
+++ b/actions-beans/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
+        <!-- For meta information processing -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.1</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/actions-beans/pom.xml
+++ b/actions-beans/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/actions-beans/pom.xml
+++ b/actions-beans/pom.xml
@@ -32,7 +32,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
-        <!-- For meta information processing -->
+        <!-- For collection processing -->
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClearAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClearAction.java
@@ -19,6 +19,6 @@ public abstract class AbstractClearAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Clear text input in element '%s'%s", buildBy(), metaInformationToString());
+        return String.format("Clear text input in element '%s'%s", buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClearAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClearAction.java
@@ -19,6 +19,6 @@ public abstract class AbstractClearAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Clear text input in element '%s'", buildBy());
+        return String.format("Clear text input in element '%s'%s", buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClickAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClickAction.java
@@ -16,6 +16,6 @@ public abstract class AbstractClickAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Click on element at element '%s'%s", buildBy(), metaInformationToString());
+        return String.format("Click on element at element '%s'%s", buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClickAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractClickAction.java
@@ -16,6 +16,6 @@ public abstract class AbstractClickAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Click on element at element '%s'", buildBy());
+        return String.format("Click on element at element '%s'%s", buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractDeselectCheckBoxAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractDeselectCheckBoxAction.java
@@ -18,6 +18,6 @@ public abstract class AbstractDeselectCheckBoxAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Unset checkbox '%s'%s", buildBy(), metaInformationToString());
+        return String.format("Unset checkbox '%s'%s", buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractDeselectCheckBoxAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractDeselectCheckBoxAction.java
@@ -18,6 +18,6 @@ public abstract class AbstractDeselectCheckBoxAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Unset checkbox '%s'", buildBy());
+        return String.format("Unset checkbox '%s'%s", buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractMouseOverAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractMouseOverAction.java
@@ -16,6 +16,6 @@ public abstract class AbstractMouseOverAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Move cursor to element '%s'%s", buildBy(), metaInformationToString());
+        return String.format("Move cursor to element '%s'%s", buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractMouseOverAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractMouseOverAction.java
@@ -16,6 +16,6 @@ public abstract class AbstractMouseOverAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Move cursor to element '%s'", buildBy());
+        return String.format("Move cursor to element '%s'%s", buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectCheckBoxAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectCheckBoxAction.java
@@ -18,6 +18,6 @@ public abstract class AbstractSelectCheckBoxAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Set checkbox '%s'%s", buildBy(), metaInformationToString());
+        return String.format("Set checkbox '%s'%s", buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectCheckBoxAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectCheckBoxAction.java
@@ -18,6 +18,6 @@ public abstract class AbstractSelectCheckBoxAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Set checkbox '%s'", buildBy());
+        return String.format("Set checkbox '%s'%s", buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectListOptionAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectListOptionAction.java
@@ -22,6 +22,6 @@ public abstract class AbstractSelectListOptionAction extends WebElementAction {
     @Override
     public String toString() {
         return String.format("Select list option number %s from selection list '%s'%s",
-                getOptionIndex(), buildBy(), metaInformationToString());
+                getOptionIndex(), buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectListOptionAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectListOptionAction.java
@@ -21,7 +21,7 @@ public abstract class AbstractSelectListOptionAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Select list option number %s from selection list '%s'",
-                getOptionIndex(), buildBy());
+        return String.format("Select list option number %s from selection list '%s'%s",
+                getOptionIndex(), buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectRadioButtonAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectRadioButtonAction.java
@@ -22,6 +22,6 @@ public abstract class AbstractSelectRadioButtonAction extends WebElementAction {
     @Override
     public String toString() {
         return String.format("Select radio button number %d from radio group '%s'%s",
-                getButtonIndex(), buildBy(), metaInformationToString());
+                getButtonIndex(), buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectRadioButtonAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractSelectRadioButtonAction.java
@@ -21,7 +21,7 @@ public abstract class AbstractSelectRadioButtonAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Select radio button number %d from radio group '%s'",
-                getButtonIndex(), buildBy());
+        return String.format("Select radio button number %d from radio group '%s'%s",
+                getButtonIndex(), buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractTypeTextAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractTypeTextAction.java
@@ -22,6 +22,6 @@ public abstract class AbstractTypeTextAction extends WebElementAction {
     @Override
     public String toString() {
         return String.format("Type text '%s' in text input '%s'%s",
-                getText(), buildBy(), metaInformationToString());
+                getText(), buildBy(), descriptionToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractTypeTextAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractTypeTextAction.java
@@ -21,6 +21,7 @@ public abstract class AbstractTypeTextAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("Type text '%s' in text input '%s'", getText(), buildBy());
+        return String.format("Type text '%s' in text input '%s'%s",
+                getText(), buildBy(), metaInformationToString());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementAction.java
@@ -17,6 +17,7 @@ public abstract class AbstractWaitForElementAction extends WebElementAction {
 
     @Override
     public String toString() {
-        return String.format("wait for '%s' maxWaitTime '%d'", buildBy(), getMaxWaitTime());
+        return String.format("wait for '%s'%s maxWaitTime '%d'",
+                buildBy(), metaInformationToString(), getMaxWaitTime());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementAction.java
@@ -18,6 +18,6 @@ public abstract class AbstractWaitForElementAction extends WebElementAction {
     @Override
     public String toString() {
         return String.format("wait for '%s'%s maxWaitTime '%d'",
-                buildBy(), metaInformationToString(), getMaxWaitTime());
+                buildBy(), descriptionToString(), getMaxWaitTime());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementToDisappearAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementToDisappearAction.java
@@ -31,6 +31,7 @@ public abstract class AbstractWaitForElementToDisappearAction extends WebElement
 
     @Override
     public String toString() {
-        return String.format("wait for '%s' to disappear maxWaitTime '%d'", buildBy(), getMaxWaitTime());
+        return String.format("wait for '%s'%s to disappear maxWaitTime '%d'",
+                buildBy(), metaInformationToString(), getMaxWaitTime());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementToDisappearAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWaitForElementToDisappearAction.java
@@ -32,6 +32,6 @@ public abstract class AbstractWaitForElementToDisappearAction extends WebElement
     @Override
     public String toString() {
         return String.format("wait for '%s'%s to disappear maxWaitTime '%d'",
-                buildBy(), metaInformationToString(), getMaxWaitTime());
+                buildBy(), descriptionToString(), getMaxWaitTime());
     }
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import ru.yandex.qatools.actions.util.SelectorUtils;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -22,12 +23,8 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
 
     public abstract List<String> getMetaInformation();
 
-    public void addMetaInformation(String metaInformation) {
-        getMetaInformation().add(metaInformation);
-    }
-
-    public void addMetaInformation(List<String> metaInformation) {
-        getMetaInformation().addAll(metaInformation);
+    public void addMetaInformation(String ... metaInformation) {
+        getMetaInformation().addAll(Arrays.asList(metaInformation));
     }
 
     @Override
@@ -44,9 +41,15 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
     }
 
     protected String metaInformationToString() {
-        return getMetaInformation().size() != 0
+        List<String> metaInformation = getMetaInformation();
+
+        if (null == metaInformation) {
+            return "";
+        } else {
+            return metaInformation.size() != 0
                 ? String.format(" with meta information %s", getMetaInformation())
                 : "";
+        }
     }
 
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -24,13 +24,13 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
 
     public abstract FindBy getFindBy();
 
-    public abstract List<String> getMetaInformation();
+    public abstract List<String> getDescription();
 
-    public void addMetaInformation(String ... metaInformation) {
-        List<String> currentMetaInformation = getMetaInformation();
+    public void addDescription(String ... description) {
+        List<String> currentDescription = getDescription();
 
-        if (!ListUtils.isNull(currentMetaInformation)) {
-            currentMetaInformation.addAll(Arrays.asList(metaInformation));
+        if (!ListUtils.isNull(currentDescription)) {
+            currentDescription.addAll(Arrays.asList(description));
         }
     }
 
@@ -47,12 +47,12 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
         return builder.toHashCode();
     }
 
-    protected String metaInformationToString() {
-        List<String> metaInformation = getMetaInformation();
+    protected String descriptionToString() {
+        List<String> description = getDescription();
 
-        return CollectionUtils.isEmpty(metaInformation)
+        return CollectionUtils.isEmpty(description)
                 ? ""
-                : String.format(" with meta information [%s]", Joiner.on(", ").join(metaInformation));
+                : String.format(" with meta information [%s]", Joiner.on(", ").join(description));
     }
 
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import ru.yandex.qatools.actions.util.ListUtils;
 import ru.yandex.qatools.actions.util.SelectorUtils;
 
 import java.util.Arrays;
@@ -26,7 +27,11 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
     public abstract List<String> getMetaInformation();
 
     public void addMetaInformation(String ... metaInformation) {
-        getMetaInformation().addAll(Arrays.asList(metaInformation));
+        List<String> currentMetaInformation = getMetaInformation();
+
+        if (!ListUtils.isNull(currentMetaInformation)) {
+            currentMetaInformation.addAll(Arrays.asList(metaInformation));
+        }
     }
 
     @Override

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -1,5 +1,7 @@
 package ru.yandex.qatools.actions.beans;
 
+import com.google.common.base.Joiner;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.openqa.selenium.By;
@@ -43,13 +45,9 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
     protected String metaInformationToString() {
         List<String> metaInformation = getMetaInformation();
 
-        if (null == metaInformation) {
-            return "";
-        } else {
-            return metaInformation.size() != 0
-                ? String.format(" with meta information %s", getMetaInformation())
-                : "";
-        }
+        return CollectionUtils.isEmpty(metaInformation)
+                ? ""
+                : String.format(" with meta information [%s]", Joiner.on(", ").join(metaInformation));
     }
 
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -52,7 +52,7 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
 
         return CollectionUtils.isEmpty(description)
                 ? ""
-                : String.format(" with meta information [%s]", Joiner.on(", ").join(description));
+                : String.format(" with description [%s]", Joiner.on(", ").join(description));
     }
 
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/beans/AbstractWebElementAction.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import ru.yandex.qatools.actions.util.SelectorUtils;
 
+import java.util.List;
+
 /**
  * @author Artem Eroshenko eroshenkoam
  *         4/19/13, 6:07 PM
@@ -18,6 +20,16 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
 
     public abstract FindBy getFindBy();
 
+    public abstract List<String> getMetaInformation();
+
+    public void addMetaInformation(String metaInformation) {
+        getMetaInformation().add(metaInformation);
+    }
+
+    public void addMetaInformation(List<String> metaInformation) {
+        getMetaInformation().addAll(metaInformation);
+    }
+
     @Override
     public boolean equals(Object o) {
         return o.getClass() == getClass() && EqualsBuilder.reflectionEquals(this, o);
@@ -29,6 +41,12 @@ public abstract class AbstractWebElementAction extends Action<WebDriver> {
         builder.appendSuper(HashCodeBuilder.reflectionHashCode(this));
         builder.append(this.getClass());
         return builder.toHashCode();
+    }
+
+    protected String metaInformationToString() {
+        return getMetaInformation().size() != 0
+                ? String.format(" with meta information %s", getMetaInformation())
+                : "";
     }
 
 }

--- a/actions-beans/src/main/java/ru/yandex/qatools/actions/util/ListUtils.java
+++ b/actions-beans/src/main/java/ru/yandex/qatools/actions/util/ListUtils.java
@@ -1,0 +1,12 @@
+package ru.yandex.qatools.actions.util;
+
+import java.util.List;
+
+/**
+ * @author Vladimir Poliakov vapolyakov
+ */
+public class ListUtils {
+    public static boolean isNull(List list) {
+        return null == list;
+    }
+}

--- a/actions-beans/src/main/resources/webelement-actions.xsd
+++ b/actions-beans/src/main/resources/webelement-actions.xsd
@@ -17,7 +17,7 @@
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="findBy" type="ns:FindBy"/>
-            <xsd:element name="metaInformation" type="xsd:string" maxOccurs="unbounded"/>
+            <xsd:element name="description" type="xsd:string" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/actions-beans/src/main/resources/webelement-actions.xsd
+++ b/actions-beans/src/main/resources/webelement-actions.xsd
@@ -17,6 +17,7 @@
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="findBy" type="ns:FindBy"/>
+            <xsd:element name="metaInformation" type="xsd:string" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/actions-builder/pom.xml
+++ b/actions-builder/pom.xml
@@ -19,8 +19,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.11</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
+++ b/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
@@ -145,19 +145,7 @@ public class Actions {
         return this;
     }
 
-
-    public Actions addMetaInformation(String metaInformation) {
-        int currentNumberOfActions = sequence.getActions().size();
-        if (currentNumberOfActions > 0) {
-            Action lastAction = sequence.getActions().get(currentNumberOfActions - 1);
-            if (lastAction instanceof AbstractWebElementAction) {
-                ((AbstractWebElementAction) lastAction).addMetaInformation(metaInformation);
-            }
-        }
-        return this;
-    }
-
-    public Actions addMetaInformation(List<String> metaInformation) {
+    public Actions addMetaInformation(String ... metaInformation) {
         int currentNumberOfActions = sequence.getActions().size();
         if (currentNumberOfActions > 0) {
             Action lastAction = sequence.getActions().get(currentNumberOfActions - 1);

--- a/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
+++ b/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
@@ -13,6 +13,7 @@ import ru.yandex.qatools.actions.listener.ProcessEventListener;
 
 import javax.xml.bind.*;
 import java.io.*;
+import java.util.List;
 
 /**
  * User: eroshenkoam, pazone
@@ -141,6 +142,29 @@ public class Actions {
         action.setFindBy(locator);
         action.setMaxWaitTime(maxWaitTime);
         sequence.append(action);
+        return this;
+    }
+
+
+    public Actions addMetaInformation(String metaInformation) {
+        int currentNumberOfActions = sequence.getActions().size();
+        if (currentNumberOfActions > 0) {
+            Action lastAction = sequence.getActions().get(currentNumberOfActions - 1);
+            if (lastAction instanceof AbstractWebElementAction) {
+                ((AbstractWebElementAction) lastAction).addMetaInformation(metaInformation);
+            }
+        }
+        return this;
+    }
+
+    public Actions addMetaInformation(List<String> metaInformation) {
+        int currentNumberOfActions = sequence.getActions().size();
+        if (currentNumberOfActions > 0) {
+            Action lastAction = sequence.getActions().get(currentNumberOfActions - 1);
+            if (lastAction instanceof AbstractWebElementAction) {
+                ((AbstractWebElementAction) lastAction).addMetaInformation(metaInformation);
+            }
+        }
         return this;
     }
 

--- a/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
+++ b/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
@@ -79,53 +79,60 @@ public class Actions {
         return this;
     }
 
-    public Actions mouseOver(FindBy locator) {
+    public Actions mouseOver(FindBy locator, String ... description) {
         MouseOverAction mouseOverAction = new MouseOverAction();
         mouseOverAction.setFindBy(locator);
+        mouseOverAction.addMetaInformation(description);
         sequence.append(mouseOverAction);
         return this;
     }
 
-    public Actions click(FindBy locator) {
+    public Actions click(FindBy locator, String ... description) {
         ClickAction clickAction = new ClickAction();
         clickAction.setFindBy(locator);
+        clickAction.addMetaInformation(description);
         sequence.append(clickAction);
         return this;
     }
 
-    public Actions typeText(FindBy locator, String text) {
+    public Actions typeText(FindBy locator, String text, String ... description) {
         TypeTextAction typeText = new TypeTextAction();
         typeText.setFindBy(locator);
         typeText.setText(text);
+        typeText.addMetaInformation(description);
         sequence.append(typeText);
         return this;
     }
 
-    public Actions clearText(FindBy locator) {
+    public Actions clearText(FindBy locator, String ... description) {
         ClearAction clear = new ClearAction();
         clear.setFindBy(locator);
+        clear.addMetaInformation(description);
         sequence.append(clear);
         return this;
     }
 
-    public Actions selectCheckbox(FindBy locator) {
+    public Actions selectCheckbox(FindBy locator, String ... description) {
         SelectCheckBoxAction selectCheckBox = new SelectCheckBoxAction();
         selectCheckBox.setFindBy(locator);
+        selectCheckBox.addMetaInformation(description);
         sequence.append(selectCheckBox);
         return this;
     }
 
-    public Actions deselectCheckbox(FindBy locator) {
+    public Actions deselectCheckbox(FindBy locator, String ... description) {
         DeselectCheckBoxAction deselectCheckBox = new DeselectCheckBoxAction();
         deselectCheckBox.setFindBy(locator);
+        deselectCheckBox.addMetaInformation(description);
         sequence.append(deselectCheckBox);
         return this;
     }
 
-    public Actions waitForElement(FindBy locator, int maxWaitTime) {
+    public Actions waitForElement(FindBy locator, int maxWaitTime, String ... description) {
         WaitForElementAction waitForElementAction = new WaitForElementAction();
         waitForElementAction.setFindBy(locator);
         waitForElementAction.setMaxWaitTime(maxWaitTime);
+        waitForElementAction.addMetaInformation(description);
         sequence.append(waitForElementAction);
         return this;
     }
@@ -137,22 +144,12 @@ public class Actions {
         return this;
     }
 
-    public Actions waitForElementToDisappear(FindBy locator, int maxWaitTime) {
+    public Actions waitForElementToDisappear(FindBy locator, int maxWaitTime, String ... description) {
         WaitForElementToDisappearAction action = new WaitForElementToDisappearAction();
         action.setFindBy(locator);
         action.setMaxWaitTime(maxWaitTime);
+        action.addMetaInformation(description);
         sequence.append(action);
-        return this;
-    }
-
-    public Actions addMetaInformation(String ... metaInformation) {
-        int currentNumberOfActions = sequence.getActions().size();
-        if (currentNumberOfActions > 0) {
-            Action lastAction = sequence.getActions().get(currentNumberOfActions - 1);
-            if (lastAction instanceof AbstractWebElementAction) {
-                ((AbstractWebElementAction) lastAction).addMetaInformation(metaInformation);
-            }
-        }
         return this;
     }
 

--- a/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
+++ b/actions-builder/src/main/java/ru/yandex/qatools/actions/Actions.java
@@ -11,10 +11,6 @@ import javax.xml.bind.Unmarshaller;
 import ru.yandex.qatools.actions.beans.*;
 import ru.yandex.qatools.actions.listener.ProcessEventListener;
 
-import javax.xml.bind.*;
-import java.io.*;
-import java.util.List;
-
 /**
  * User: eroshenkoam, pazone
  * Date: 9/2/12, 5:08 PM
@@ -82,7 +78,7 @@ public class Actions {
     public Actions mouseOver(FindBy locator, String ... description) {
         MouseOverAction mouseOverAction = new MouseOverAction();
         mouseOverAction.setFindBy(locator);
-        mouseOverAction.addMetaInformation(description);
+        mouseOverAction.addDescription(description);
         sequence.append(mouseOverAction);
         return this;
     }
@@ -90,7 +86,7 @@ public class Actions {
     public Actions click(FindBy locator, String ... description) {
         ClickAction clickAction = new ClickAction();
         clickAction.setFindBy(locator);
-        clickAction.addMetaInformation(description);
+        clickAction.addDescription(description);
         sequence.append(clickAction);
         return this;
     }
@@ -99,7 +95,7 @@ public class Actions {
         TypeTextAction typeText = new TypeTextAction();
         typeText.setFindBy(locator);
         typeText.setText(text);
-        typeText.addMetaInformation(description);
+        typeText.addDescription(description);
         sequence.append(typeText);
         return this;
     }
@@ -107,7 +103,7 @@ public class Actions {
     public Actions clearText(FindBy locator, String ... description) {
         ClearAction clear = new ClearAction();
         clear.setFindBy(locator);
-        clear.addMetaInformation(description);
+        clear.addDescription(description);
         sequence.append(clear);
         return this;
     }
@@ -115,7 +111,7 @@ public class Actions {
     public Actions selectCheckbox(FindBy locator, String ... description) {
         SelectCheckBoxAction selectCheckBox = new SelectCheckBoxAction();
         selectCheckBox.setFindBy(locator);
-        selectCheckBox.addMetaInformation(description);
+        selectCheckBox.addDescription(description);
         sequence.append(selectCheckBox);
         return this;
     }
@@ -123,7 +119,7 @@ public class Actions {
     public Actions deselectCheckbox(FindBy locator, String ... description) {
         DeselectCheckBoxAction deselectCheckBox = new DeselectCheckBoxAction();
         deselectCheckBox.setFindBy(locator);
-        deselectCheckBox.addMetaInformation(description);
+        deselectCheckBox.addDescription(description);
         sequence.append(deselectCheckBox);
         return this;
     }
@@ -132,7 +128,7 @@ public class Actions {
         WaitForElementAction waitForElementAction = new WaitForElementAction();
         waitForElementAction.setFindBy(locator);
         waitForElementAction.setMaxWaitTime(maxWaitTime);
-        waitForElementAction.addMetaInformation(description);
+        waitForElementAction.addDescription(description);
         sequence.append(waitForElementAction);
         return this;
     }
@@ -148,7 +144,7 @@ public class Actions {
         WaitForElementToDisappearAction action = new WaitForElementToDisappearAction();
         action.setFindBy(locator);
         action.setMaxWaitTime(maxWaitTime);
-        action.addMetaInformation(description);
+        action.addDescription(description);
         sequence.append(action);
         return this;
     }

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -3,8 +3,10 @@ package ru.yandex.qatools.actions;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -94,8 +96,10 @@ public class ScenarioTest {
         inOrder.verify(driver.switchTo().alert()).accept();
 
         List<Action> readActions = actions.build().getActions();
-        assertEquals(4, readActions.size());
-        assertTrue(readActions.get(2) instanceof AbstractWebElementAction);
-        assertEquals(EXPECTED_META_INFORMATION_LIST, ((AbstractWebElementAction) readActions.get(2)).getMetaInformation());
+        assertThat("Check the number of deserialized actions", readActions, hasSize(4));
+        assertThat("Check that the third action can contain some meta information",
+                readActions.get(2), instanceOf(AbstractWebElementAction.class));
+        assertThat("Check read meta information",
+                ((AbstractWebElementAction) readActions.get(2)).getMetaInformation(), is(EXPECTED_META_INFORMATION_LIST));
     }
 }

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -3,10 +3,15 @@ package ru.yandex.qatools.actions;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +21,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import ru.yandex.qatools.actions.beans.AbstractWebElementAction;
+import ru.yandex.qatools.actions.beans.Action;
 import ru.yandex.qatools.actions.beans.FindBy;
 
 /**
@@ -28,6 +35,7 @@ public class ScenarioTest {
     private static final String SEARCH_BUTTON_XPATH = "//input[@class='b-form-button__input']";
     private static final String TEST_REQUEST = "Yandex";
     private static final String META_INFORMATION = "Meta Information";
+    private static final List<String> EXPECTED_META_INFORMATION_LIST = Arrays.asList(META_INFORMATION, META_INFORMATION);
 
     private static WebDriver driver;
 
@@ -84,5 +92,10 @@ public class ScenarioTest {
         inOrder.verify(driver.findElement(By.xpath(SEARCH_INPUT_XPATH))).sendKeys(TEST_REQUEST);
         inOrder.verify(driver.findElement(By.xpath(SEARCH_BUTTON_XPATH))).click();
         inOrder.verify(driver.switchTo().alert()).accept();
+
+        List<Action> readActions = actions.build().getActions();
+        assertEquals(4, readActions.size());
+        assertTrue(readActions.get(2) instanceof AbstractWebElementAction);
+        assertEquals(EXPECTED_META_INFORMATION_LIST, ((AbstractWebElementAction) readActions.get(2)).getMetaInformation());
     }
 }

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -36,8 +36,8 @@ public class ScenarioTest {
     private static final String SEARCH_INPUT_XPATH = "//input[@class='b-form-input__input']";
     private static final String SEARCH_BUTTON_XPATH = "//input[@class='b-form-button__input']";
     private static final String TEST_REQUEST = "Yandex";
-    private static final String META_INFORMATION = "Meta Information";
-    private static final List<String> EXPECTED_META_INFORMATION_LIST = Arrays.asList(META_INFORMATION, META_INFORMATION);
+    private static final String DESCRIPTION = "Description";
+    private static final List<String> EXPECTED_DESCRIPTION = Arrays.asList(DESCRIPTION, DESCRIPTION);
 
     private static WebDriver driver;
 
@@ -78,7 +78,7 @@ public class ScenarioTest {
         Actions actions = new Actions();
         actions.loadPage(PAGE_URL).
                 typeText(FindBy.xpath(SEARCH_INPUT_XPATH), TEST_REQUEST).
-                click(FindBy.xpath(SEARCH_BUTTON_XPATH), META_INFORMATION, META_INFORMATION).
+                click(FindBy.xpath(SEARCH_BUTTON_XPATH), DESCRIPTION, DESCRIPTION).
                 alertAccept();
         File actionsFile = new File("search-request-scenario.xml");
         actions.write(actionsFile.getPath());
@@ -100,6 +100,6 @@ public class ScenarioTest {
         assertThat("Check that the third action can contain some meta information",
                 readActions.get(2), instanceOf(AbstractWebElementAction.class));
         assertThat("Check read meta information",
-                ((AbstractWebElementAction) readActions.get(2)).getMetaInformation(), is(EXPECTED_META_INFORMATION_LIST));
+                ((AbstractWebElementAction) readActions.get(2)).getDescription(), is(EXPECTED_DESCRIPTION));
     }
 }

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -36,8 +36,9 @@ public class ScenarioTest {
     private static final String SEARCH_INPUT_XPATH = "//input[@class='b-form-input__input']";
     private static final String SEARCH_BUTTON_XPATH = "//input[@class='b-form-button__input']";
     private static final String TEST_REQUEST = "Yandex";
-    private static final String DESCRIPTION = "Description";
-    private static final List<String> EXPECTED_DESCRIPTION = Arrays.asList(DESCRIPTION, DESCRIPTION);
+    private static final String DESCRIPTION_1 = "Description 1";
+    private static final String DESCRIPTION_2 = "Description 2";
+    private static final List<String> EXPECTED_DESCRIPTION = Arrays.asList(DESCRIPTION_1, DESCRIPTION_2);
 
     private static WebDriver driver;
 
@@ -78,7 +79,7 @@ public class ScenarioTest {
         Actions actions = new Actions();
         actions.loadPage(PAGE_URL).
                 typeText(FindBy.xpath(SEARCH_INPUT_XPATH), TEST_REQUEST).
-                click(FindBy.xpath(SEARCH_BUTTON_XPATH), DESCRIPTION, DESCRIPTION).
+                click(FindBy.xpath(SEARCH_BUTTON_XPATH), DESCRIPTION_1, DESCRIPTION_2).
                 alertAccept();
         File actionsFile = new File("search-request-scenario.xml");
         actions.write(actionsFile.getPath());
@@ -97,9 +98,9 @@ public class ScenarioTest {
 
         List<Action> readActions = actions.build().getActions();
         assertThat("Check the number of deserialized actions", readActions, hasSize(4));
-        assertThat("Check that the third action can contain some meta information",
+        assertThat("Check that the third action can contain description",
                 readActions.get(2), instanceOf(AbstractWebElementAction.class));
-        assertThat("Check read meta information",
+        assertThat("Check read description",
                 ((AbstractWebElementAction) readActions.get(2)).getDescription(), is(EXPECTED_DESCRIPTION));
     }
 }

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -68,9 +68,7 @@ public class ScenarioTest {
         Actions actions = new Actions();
         actions.loadPage(PAGE_URL).
                 typeText(FindBy.xpath(SEARCH_INPUT_XPATH), TEST_REQUEST).
-                click(FindBy.xpath(SEARCH_BUTTON_XPATH)).
-                addMetaInformation(META_INFORMATION).
-                addMetaInformation(META_INFORMATION).
+                click(FindBy.xpath(SEARCH_BUTTON_XPATH), META_INFORMATION, META_INFORMATION).
                 alertAccept();
         File actionsFile = new File("search-request-scenario.xml");
         actions.write(actionsFile.getPath());

--- a/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
+++ b/actions-builder/src/test/java/ru/yandex/qatools/actions/ScenarioTest.java
@@ -27,6 +27,7 @@ public class ScenarioTest {
     private static final String SEARCH_INPUT_XPATH = "//input[@class='b-form-input__input']";
     private static final String SEARCH_BUTTON_XPATH = "//input[@class='b-form-button__input']";
     private static final String TEST_REQUEST = "Yandex";
+    private static final String META_INFORMATION = "Meta Information";
 
     private static WebDriver driver;
 
@@ -68,6 +69,8 @@ public class ScenarioTest {
         actions.loadPage(PAGE_URL).
                 typeText(FindBy.xpath(SEARCH_INPUT_XPATH), TEST_REQUEST).
                 click(FindBy.xpath(SEARCH_BUTTON_XPATH)).
+                addMetaInformation(META_INFORMATION).
+                addMetaInformation(META_INFORMATION).
                 alertAccept();
         File actionsFile = new File("search-request-scenario.xml");
         actions.write(actionsFile.getPath());

--- a/actions-builder/src/test/resources/search-request-scenario.xml
+++ b/actions-builder/src/test/resources/search-request-scenario.xml
@@ -9,6 +9,8 @@
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:ClickAction">
 		<findBy xpath="//input[@class='b-form-button__input']" />
+		<metaInformation>Meta Information</metaInformation>
+		<metaInformation>Meta Information</metaInformation>
 	</actions>
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:AlertAcceptAction" />

--- a/actions-builder/src/test/resources/search-request-scenario.xml
+++ b/actions-builder/src/test/resources/search-request-scenario.xml
@@ -9,8 +9,8 @@
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:ClickAction">
 		<findBy xpath="//input[@class='b-form-button__input']" />
-		<description>Description</description>
-		<description>Description</description>
+		<description>Description 1</description>
+		<description>Description 2</description>
 	</actions>
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:AlertAcceptAction" />

--- a/actions-builder/src/test/resources/search-request-scenario.xml
+++ b/actions-builder/src/test/resources/search-request-scenario.xml
@@ -9,8 +9,8 @@
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:ClickAction">
 		<findBy xpath="//input[@class='b-form-button__input']" />
-		<metaInformation>Meta Information</metaInformation>
-		<metaInformation>Meta Information</metaInformation>
+		<description>Description</description>
+		<description>Description</description>
 	</actions>
 	<actions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:type="ns2:AlertAcceptAction" />


### PR DESCRIPTION
Добавляет возможность вместе с xpath хранить в Action'ах ещё и мета информацию о поле (текст со страницы, релевантный полю ввода).
В итоге влияет только на сериализацию Actions и метод .toString() у отдельных Action'ов. В тесте Actions.write() такая мета информация присутствует.
Сериализуется в виде нескольких элементов <metaInformation>, а в toString() добавляется в подходящем месте строка "with meta information [список мета информации]".
